### PR TITLE
[READY] [NODOCS] [NOTESTS] feat(hook): add use-pagination hook

### DIFF
--- a/lib/hooks/usePagination.ts
+++ b/lib/hooks/usePagination.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface IUsePagination {
+  currentPage: number;
+  setPage: (page: number) => void;
+  goToPreviousPage: () => void;
+  goToNextPage: () => void;
+  nextPageDisabled: boolean;
+  previousPageDisabled: boolean;
+}
+
+export function usePagination(totalPages: number): IUsePagination {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const goToPreviousPage = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 1));
+  };
+
+  const goToNextPage = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
+  };
+
+  const nextPageDisabled = currentPage === totalPages;
+  const previousPageDisabled = currentPage === 1;
+
+  const setPage = (page: number) => {
+    if (page < 1) {
+      setCurrentPage(1);
+    } else if (page > totalPages) {
+      setCurrentPage(totalPages);
+    } else {
+      setCurrentPage(page);
+    }
+  };
+
+  return {
+    currentPage,
+    setPage,
+    goToPreviousPage,
+    goToNextPage,
+    nextPageDisabled,
+    previousPageDisabled,
+  };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,6 +38,7 @@ export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
 export { useKeyPress } from './hooks/useKeyPress';
 export { useScrollDevice } from './hooks/useScrollDevice';
+export { usePagination } from './hooks/usePagination';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-haiku",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-haiku",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "react": ">=16.8.0"


### PR DESCRIPTION
This PR adds a usePagination hook to simplify pagination management in React projects. The hook provides the following features:

Tracks the current page (currentPage).
Functions to navigate to the next and previous pages (goToNextPage, goToPreviousPage).
Allows setting a specific page with validation (setPage).
Disables navigation when at the first or last page (nextPageDisabled, previousPageDisabled).