### PR TITLE
Feat/98 add websocket hook

### DIFF
--- a/docs/docs/hooks/useWebSocket.mdx
+++ b/docs/docs/hooks/useWebSocket.mdx
@@ -1,0 +1,50 @@
+# useWebSocket()
+
+The `useWebSocket()` hook manages WebSocket connections, providing automatic reconnection and state management. It includes functions to send messages and callbacks for different WebSocket events.
+
+### Import
+
+```jsx
+import { useWebSocket } from 'react-haiku';
+```
+
+### Usage
+
+```jsx
+import { useWebSocket, WebSocketStatus } from './path-to-your-hook';
+
+export const WebSocketComponent = () => {
+  const { lastMessage, status, sendMessage } = useWebSocket(
+    'wss://example.com/socket',
+    {
+      maxReconnectAttempts: 5,
+      reconnectDelay: (attempt) => Math.min(5000, Math.pow(2, attempt) * 1000),
+      onOpen: () => console.log('WebSocket opened!'),
+      onMessage: (message) => console.log('Received message:', message),
+      onError: (error) => console.error('WebSocket error:', error),
+      onClose: (event) => console.log('WebSocket closed:', event),
+    },
+  );
+
+  return (
+    <div>
+      <h3>WebSocket Status: {status}</h3>
+      <p>Last message: {lastMessage}</p>
+      <button onClick={() => sendMessage('Hello WebSocket!')}>
+        Send Message
+      </button>
+    </div>
+  );
+};
+```
+
+### Parameters
+
+- url (string) – The WebSocket URL to connect to.
+- options (object) – Optional configuration options:
+  - `maxReconnectAttempts` (number) – Max attempts for reconnection. Default is 5.
+  - `reconnectDelay` (function) – A function to calculate the delay between reconnection attempts. Default is exponential backoff.
+  - `onOpen` (function) – Callback function triggered when the WebSocket connection is opened.
+  - `onMessage` (function) – Callback function triggered when a message is received.
+  - `onError` (function) – Callback function triggered when an error occurs.
+  - `onClose` (function) – Callback function triggered when the WebSocket connection is closed.

--- a/docs/docs/hooks/useWebSocket.mdx
+++ b/docs/docs/hooks/useWebSocket.mdx
@@ -11,7 +11,7 @@ import { useWebSocket } from 'react-haiku';
 ### Usage
 
 ```jsx
-import { useWebSocket, WebSocketStatus } from './path-to-your-hook';
+import { useWebSocket } from './path-to-your-hook';
 
 export const WebSocketComponent = () => {
   const { lastMessage, status, sendMessage } = useWebSocket(

--- a/lib/hooks/useWebSocket.ts
+++ b/lib/hooks/useWebSocket.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from 'react';
+
+export enum WebSocketStatus {
+  CONNECTING = 'CONNECTING',
+  OPEN = 'OPEN',
+  CLOSED = 'CLOSED',
+  RECONNECTING = 'RECONNECTING',
+}
+
+export interface WebSocketHook {
+  lastMessage: string | null;
+  status: WebSocketStatus;
+  sendMessage: (message: string) => void;
+}
+export interface WebSocketOptions {
+  maxReconnectAttempts?: number; // Max attempts for reconnection
+  reconnectDelay?: (attempt: number) => number; // Function to calculate delay
+  onOpen?: () => void; // Callback for WebSocket open event
+  onMessage?: (message: string) => void; // Callback for incoming messages
+  onError?: (error: Event) => void; // Callback for WebSocket errors
+  onClose?: (event: CloseEvent) => void; // Callback for WebSocket close event
+}
+
+/**
+ * hook to manage WebSocket connections with auto-reconnect and state management.
+ * @param url - WebSocket URL to connect to.
+ * @param options - Configuration options for WebSocket behavior.
+ * @returns WebSocketHook containing state and utility functions.
+ */
+
+export const useWebSocket = (
+  url: string,
+  {
+    maxReconnectAttempts = 5,
+    reconnectDelay = (attempt) => Math.min(5000, Math.pow(2, attempt) * 1000), // Default: exponential backoff
+    onOpen,
+    onMessage,
+    onError,
+    onClose,
+  }: WebSocketOptions = {},
+): WebSocketHook => {
+  const [lastMessage, setLastMessage] = useState<string | null>(null);
+  const [status, setStatus] = useState<WebSocketStatus>(
+    WebSocketStatus.CONNECTING,
+  );
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectAttempts = useRef<number>(0); // Tracks reconnection attempts
+
+  const connectWebSocket = () => {
+    setStatus(WebSocketStatus.CONNECTING);
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setStatus(WebSocketStatus.OPEN);
+      reconnectAttempts.current = 0; // Reset reconnection attempts
+      onOpen?.(); // Trigger custom callback
+    };
+
+    ws.onmessage = (event) => {
+      setLastMessage(event.data);
+      onMessage?.(event.data); // Trigger custom callback
+    };
+
+    ws.onerror = (error) => {
+      onError?.(error); // Trigger custom callback
+    };
+
+    ws.onclose = (event) => {
+      setStatus(WebSocketStatus.CLOSED);
+      onClose?.(event); // Trigger custom callback
+
+      // Attempt to reconnect if below the max attempts
+      if (reconnectAttempts.current < maxReconnectAttempts) {
+        reconnectAttempts.current += 1;
+        setStatus(WebSocketStatus.RECONNECTING);
+        setTimeout(connectWebSocket, reconnectDelay(reconnectAttempts.current));
+      }
+    };
+  };
+
+  const sendMessage = (message: string) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(message);
+    } else {
+      console.warn('WebSocket is not open.');
+    }
+  };
+
+  useEffect(() => {
+    connectWebSocket();
+
+    return () => {
+      wsRef.current?.close();
+    };
+  }, [url]);
+
+  return { lastMessage, status, sendMessage };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-haiku",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-haiku",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "react": ">=16.8.0"


### PR DESCRIPTION
## Pull Request Description:

### Summary:
This pull request introduces a new `useWebSocket()` hook to React Haiku, enabling easy management of WebSocket connections in React applications.

### Features:

- WebSocket Connection Management
- Auto-Reconnect
- Callbacks for Custom Behavior.
- Exposes a send method to send messages via the WebSocket.

### Usage

```jsx

import React from 'react';
import { useWebSocket } from 'react-haiku';

const WebSocketComponent = () => {
  const { lastMessage, status, sendMessage } = useWebSocket('wss://example.com/socket', {
    maxReconnectAttempts: 3,
    reconnectDelay: (attempt) => Math.min(5000, Math.pow(2, attempt) * 1000),
    onOpen: () => console.log('Connected to WebSocket'),
    onMessage: (message) => console.log('Received message:', message),
    onError: (error) => console.error('WebSocket error:', error),
    onClose: (event) => console.log('WebSocket closed:', event),
  });

  return (
    <div>
      <h1>WebSocket Hook</h1>
      <p>Status: {status}</p>
      <button onClick={() => sendMessage('Hello, Server!')}>Send Message</button>
      <p>Received Data: {lastMessage}</p>
    </div>
  );
};
```