### PR TITLE
[READY] feat(hook): add `usePrevious` hook

### DIFF
--- a/docs/demo/UsePreviousDemo.tsx
+++ b/docs/demo/UsePreviousDemo.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useState } from "react";
+import { usePrevious } from "react-haiku"
+
+export const UsePreviousDemo = () => {
+  const [count, setCount] = useState(0);
+  const prevCount = usePrevious(count);
+
+  function handleIncrement() {
+    setCount(prev => prev + 1)
+  }
+
+  function handleDecrement() {
+    setCount(prev => prev - 1)
+  }
+
+  return (
+    <div className="demo-container-center">
+      <h3 style={{ marginBottom: '1em' }}>Current Value: {count}</h3>
+      <h3 style={{ marginBottom: '1em' }}>Previous Value: {prevCount}</h3>
+
+      <div style={{ marginTop: '1.5em', display: 'flex', gap: '1em' }}>
+        <button className="demo-button green-button" onClick={handleIncrement}>
+          Increment
+        </button>
+        <button className="demo-button red-button" onClick={handleDecrement}>
+          Decrement
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/docs/hooks/usePrevious.mdx
+++ b/docs/docs/hooks/usePrevious.mdx
@@ -1,0 +1,54 @@
+# usePrevious()
+
+The `usePrevious()` tracks and returns the previous value of a given input
+
+### Import
+
+```jsx
+import { usePrevious } from 'react-haiku';
+```
+
+### Usage
+
+import { UsePreviousDemo } from '../../demo/UsePreviousDemo.tsx';
+
+<UsePreviousDemo />
+
+```jsx
+import { usePrevious } from 'react-haiku';
+
+export const Component = () => {
+  const [count, setCount] = useState(0);
+  const prevCount = usePrevious(count);
+
+  function handleIncrement() {
+    setCount(prev => prev + 1)
+  }
+
+  function handleDecrement() {
+    setCount(prev => prev - 1)
+  }
+
+  return (
+    <div>
+      <h3>Current Value: {count}</h3>
+      <h3>Previous Value: {prevCount}</h3>
+
+      <div>
+        <button onClick={handleIncrement}>
+          Increment
+        </button>
+        <button onClick={handleDecrement}>
+          Decrement
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+### API
+
+#### Arguments
+
+- `value` - The new value to track and return the previous of

--- a/lib/hooks/usePrevious.ts
+++ b/lib/hooks/usePrevious.ts
@@ -1,0 +1,19 @@
+import { useRef } from 'react';
+
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+
+/**
+ * Tracks the previous value of a given input.
+ *
+ * @param {T} value The current value to track.
+ * @returns {T} The previous value of the input, or `value` if it's the first render.
+ */
+export const usePrevious = <T>(value: T): T => {
+  const ref = useRef(value)
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = value
+  }, [value])
+
+  return ref.current
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -36,6 +36,7 @@ export { useOrientation } from './hooks/useOrientation';
 export { useWindowSize } from './hooks/useWindowSize';
 export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
+export { usePrevious } from './hooks/usePrevious';
 export { useKeyPress } from './hooks/useKeyPress';
 export { useScrollDevice } from './hooks/useScrollDevice';
 

--- a/lib/tests/hooks/usePrevious.test.tsx
+++ b/lib/tests/hooks/usePrevious.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePrevious } from "../../hooks/usePrevious";
+
+describe('usePrevious Hook', () => {
+  test('returns the initial value initially', () => {
+    const initialValue = "initial"
+
+    const { result } = renderHook(() => usePrevious(initialValue));
+    expect(result.current).toBe(initialValue);
+  });
+
+  test('returns the previous value', () => {
+    const initialValue = "initial"
+
+    const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+      initialProps: {
+        value: initialValue
+      }
+    });
+
+    expect(result.current).toBe(initialValue)
+
+    act(() => {
+      rerender({ value: "previous" });
+    });
+
+    expect(result.current).toBe(initialValue)
+
+    act(() => {
+      rerender({ value: "next" });
+    });
+
+    expect(result.current).toBe("previous")
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-haiku",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-haiku",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "react": ">=16.8.0"


### PR DESCRIPTION
## Pull Request Description:

### Summary:
This pull request introduces a new `usePrevious()` hook to React Haiku, enabling easy track the previous value of some input in React applications.

### Usage

```ts
import { usePrevious } from 'react-haiku';

export const UsePreviousComponent = () => {
  const [count, setCount] = useState(0);
  const prevCount = usePrevious(count);

  function handleIncrement() {
    setCount(prev => prev + 1)
  }

  function handleDecrement() {
    setCount(prev => prev - 1)
  }

  return (
    <div>
      <h3>Current Value: {count}</h3>
      <h3>Previous Value: {prevCount}</h3>

      <div>
        <button onClick={handleIncrement}>
          Increment
        </button>
        <button onClick={handleDecrement}>
          Decrement
        </button>
      </div>
    </div>
  );
}
```