### PR TITLE
fix(hook): add `as const` assertion in `useInputValue` return type

### DIFF
--- a/lib/hooks/useInputValue.ts
+++ b/lib/hooks/useInputValue.ts
@@ -22,5 +22,5 @@ export function handleChange<T>(setValue: React.Dispatch<any>) {
 export function useInputValue<T>(initialState: T) {
   const [value, setValue] = useState<T>(initialState);
 
-  return [value, handleChange<T>(setValue)];
+  return [value, handleChange<T>(setValue)] as const;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-haiku",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-haiku",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "react": ">=16.8.0"


### PR DESCRIPTION
## Pull Request Description:

### Summary:
This pull request fixes the return type in the `useInputValue()` hook, as mentioned in #106


### Solution
Add the assertion `as const` to the return type of the hook.