### PR TITLE
test(useEventListener): add test to verify event listener behavior

### DIFF
--- a/lib/tests/hooks/useEventListener.test.tsx
+++ b/lib/tests/hooks/useEventListener.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook, act } from '@testing-library/react';
+import { useEventListener } from '../../hooks/useEventListener';
+
+describe('useEventListener Hook', () => {
+  test('adds and triggers event listener correctly', () => {
+    const handler = jest.fn();
+
+    const { unmount } = renderHook(() => useEventListener('click', handler));
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('click'));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('click'));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1); // Should not trigger after unmount
+  });
+});


### PR DESCRIPTION
This PR adds a test to cover the behavior of the `useEventListener` hook. The test verifies that the hook correctly adds a listener for the click event and that the `handler` function is called when the event is triggered. Additionally, after unmounting the hook, a new click event is dispatched to ensure that the `handler` is not called again, validating the removal of the event listener.