### PR TITLE
feat(hook): add `usePermission` hook

### DIFF
--- a/docs/demo/UsePermissionDemo.tsx
+++ b/docs/demo/UsePermissionDemo.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useState } from "react";
+import { usePermission } from "react-haiku"
+
+export const UsePermissionDemo = () => {
+  const state = usePermission("geolocation")
+  const [location, setLocation] = useState<GeolocationPosition | null>(null)
+
+  function handleGetCurrentPosition() {
+    if (state !== "prompt" && state !== "granted") return
+
+    navigator.geolocation.getCurrentPosition((location) => {
+      setLocation(location)
+    })
+  }
+
+  return (
+    <div className="demo-container-center">
+      <h3 style={{ marginBottom: '1em' }}>Permission state: {state}</h3>
+
+      <pre>
+        {JSON.stringify(location ?? {}, null, 2)}
+      </pre>
+
+      <div style={{ marginTop: '1em', display: 'flex', gap: '1em' }}>
+        <button
+          className="demo-button green-button"
+          onClick={handleGetCurrentPosition}
+        >
+          Get current position
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/docs/hooks/usePermission.mdx
+++ b/docs/docs/hooks/usePermission.mdx
@@ -1,6 +1,6 @@
 # usePermission()
 
-The `usePermission()` check browser permissions for querying status for various browser APIs
+The `usePermission()` check browser permissions for querying state for various browser APIs
 
 ### Import
 
@@ -32,7 +32,7 @@ export const Component = () => {
 
   return (
     <div>
-      <h3>Permission state: {status}</h3>
+      <h3>Permission state: {state}</h3>
 
       <pre>
         {JSON.stringify(location ?? {}, null, 2)}
@@ -57,5 +57,5 @@ export const Component = () => {
 #### Returns
 
 The the state of a requested permission, combining the standard `PermissionState` with additional internal states.
-  - `checking`: The permission status is being verified.
+  - `checking`: The permission state is being verified.
   - `not-supported`: The permission check is not supported or an error occurred during verification.

--- a/docs/docs/hooks/usePermission.mdx
+++ b/docs/docs/hooks/usePermission.mdx
@@ -1,0 +1,61 @@
+# usePermission()
+
+The `usePermission()` check browser permissions for querying status for various browser APIs
+
+### Import
+
+```jsx
+import { usePermission } from 'react-haiku';
+```
+
+### Usage
+
+import { UsePermissionDemo } from '../../demo/UsePermissionDemo.tsx';
+
+<UsePermissionDemo />
+
+```tsx
+import { useState } from 'react';
+import { usePermission } from 'react-haiku';
+
+export const Component = () => {
+  const state = usePermission("geolocation")
+  const [location, setLocation] = useState<GeolocationPosition | null>(null)
+
+  function handleGetCurrentPosition() {
+    if (state !== "prompt" && state !== "granted") return
+
+    navigator.geolocation.getCurrentPosition((location) => {
+      setLocation(location)
+    })
+  }
+
+  return (
+    <div>
+      <h3>Permission state: {status}</h3>
+
+      <pre>
+        {JSON.stringify(location ?? {}, null, 2)}
+      </pre>
+
+      <div>
+        <button onClick={handleGetCurrentPosition}>
+          Get current position
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+### API
+
+#### Arguments
+
+- `permission` - The name of the API whose permissions you want to query, such as the `PermissionName` and other described in the [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query#name) documentation.
+
+#### Returns
+
+The the state of a requested permission, combining the standard `PermissionState` with additional internal states.
+  - `checking`: The permission status is being verified.
+  - `not-supported`: The permission check is not supported or an error occurred during verification.

--- a/lib/hooks/usePermission.ts
+++ b/lib/hooks/usePermission.ts
@@ -1,0 +1,79 @@
+import { useCallback, useRef, useState } from 'react'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+
+/**
+ * Name of the API whose permissions you want to query
+ * @link [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query#name)
+ */
+type Permission =
+  PermissionName |
+  'accelerometer' |
+  'accessibility-events' |
+  'ambient-light-sensor' |
+  'background-sync' |
+  'camera' |
+  'clipboard-read' |
+  'clipboard-write' |
+  'gyroscope' |
+  'local-fonts' |
+  'magnetometer' |
+  'microphone' |
+  'payment-handler' |
+  'top-level-storage-access' |
+  'window-management'
+
+/**
+ * Represents the state of a requested permission, combining the standard `PermissionState` with additional internal states.
+ *
+ * - `checking`: The permission status is being verified.
+ * - `not-supported`: The permission check is not supported or an error occurred during verification.
+ *
+ * @link [`PermissionState`](https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus/state)
+ */
+export type UsePermissionState = PermissionState | 'checking' | 'not-supported';
+
+/**
+ * Check browser permissions for querying status for various browser APIs
+ *
+ * @param {Permission} permission The name of the permission to query.
+ * @return {UsePermissionState} The state of a requested permission
+ */
+export const usePermission = (permission: Permission): UsePermissionState => {
+  const [state, setState] = useState<UsePermissionState>('checking');
+  const status = useRef<PermissionStatus | null>(null)
+
+  const handleStatusChange = useCallback((event: Event) => {
+    const target = event.target as PermissionStatus
+    setState(target.state)
+  }, [])
+
+  const checkPermission = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.permissions) {
+      setState('not-supported')
+      return
+    }
+
+    try {
+      const result = await navigator.permissions.query({
+        name: permission as PermissionName
+      })
+
+      setState(result.state)
+      result.addEventListener('change', handleStatusChange)
+      status.current = result
+    } catch {
+      setState('not-supported')
+      status.current = null
+    }
+  }, [permission, handleStatusChange])
+
+  useIsomorphicLayoutEffect(() => {
+    checkPermission()
+
+    return () => {
+      status.current?.removeEventListener('change', handleStatusChange)
+    }
+  }, [checkPermission, handleStatusChange])
+
+  return state
+}

--- a/lib/hooks/usePermission.ts
+++ b/lib/hooks/usePermission.ts
@@ -25,7 +25,7 @@ type Permission =
 /**
  * Represents the state of a requested permission, combining the standard `PermissionState` with additional internal states.
  *
- * - `checking`: The permission status is being verified.
+ * - `checking`: The permission state is being verified.
  * - `not-supported`: The permission check is not supported or an error occurred during verification.
  *
  * @link [`PermissionState`](https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus/state)
@@ -33,7 +33,7 @@ type Permission =
 export type UsePermissionState = PermissionState | 'checking' | 'not-supported';
 
 /**
- * Check browser permissions for querying status for various browser APIs
+ * Check browser permissions for querying state for various browser APIs
  *
  * @param {Permission} permission The name of the permission to query.
  * @return {UsePermissionState} The state of a requested permission

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,6 +38,7 @@ export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
 export { useKeyPress } from './hooks/useKeyPress';
 export { useScrollDevice } from './hooks/useScrollDevice';
+export { usePermission, UsePermissionState } from './hooks/usePermission';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';

--- a/lib/tests/hooks/usePermission.test.tsx
+++ b/lib/tests/hooks/usePermission.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePermission } from '../../hooks/usePermission';
+
+describe('usePermission Hook', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: {
+        query: jest.fn(),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the not-supported state when navigator-permissions is not present', () => {
+    // @ts-ignore
+    navigator.permissions = null
+
+    const { result } = renderHook(() => usePermission('geolocation'));
+    expect(result.current).toBe('not-supported');
+  });
+
+  it('should return the checking state initially', () => {
+    navigator.permissions.query = jest.fn().mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => usePermission('geolocation'));
+    expect(result.current).toBe('checking');
+  });
+
+  it('should return the not-supported state when some error occurred', async () => {
+    navigator.permissions.query = jest.fn().mockRejectedValueOnce(new Error())
+
+    const { result } = renderHook(() => usePermission('geolocation'));
+
+    await waitFor(() => {
+      expect(result.current).toBe('not-supported');
+    })
+  });
+
+  it('should return the prompt state', async () => {
+    navigator.permissions.query = jest.fn().mockResolvedValue({
+      state: 'prompt',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    });
+
+    const { result } = renderHook(() => usePermission('geolocation'));
+
+    await waitFor(() => {
+      expect(result.current).toBe('prompt');
+    })
+  });
+
+  it('should return the granted state', async () => {
+    navigator.permissions.query = jest.fn().mockResolvedValue({
+      state: 'granted',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    });
+
+    const { result } = renderHook(() => usePermission('geolocation'));
+
+    await waitFor(() => {
+      expect(result.current).toBe('granted');
+    })
+  });
+
+  it('should return the denied state', async () => {
+    navigator.permissions.query = jest.fn().mockResolvedValue({
+      state: 'denied',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    });
+
+    const { result } = renderHook(() => usePermission('geolocation'));
+
+    await waitFor(() => {
+      expect(result.current).toBe('denied');
+    })
+  });
+});


### PR DESCRIPTION
## Pull Request Description:

### Summary:
This pull request introduces a new `usePermission()` hook mentioned in #95, enabling easy check browser permissions for querying status for various browser APIs in React applications.

### Usage

```tsx
import { usePermission } from 'react-haiku';

export const Component = () => {
  const state = usePermission("geolocation")

  return (
    <div>
      <h3>Permission state: {state}</h3>
    </div>
  );
}
```