### PR TITLE
Feat/94: add `useTimer()` hook

### DIFF
--- a/docs/demo/UseTimerDemo.jsx
+++ b/docs/demo/UseTimerDemo.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useTimer } from 'react-haiku';
+
+export const UseTimerDemo = () => {
+  const { time, isRunning, start, pause, reset } = useTimer({
+    startTime: 0,
+    endTime: 10000,
+    interval: 1000,
+  });
+
+  return (
+    <div className="demo-container-center">
+      <h3 style={{ marginBottom: '1em' }}>Time: {time}</h3>
+      <div className="demo-control-group">
+        <button
+          className="demo-button orange-button"
+          onClick={start}
+          disabled={isRunning}
+        >
+          Start
+        </button>
+
+        <button
+          className="demo-button orange-button"
+          onClick={pause}
+          disabled={!isRunning}
+        >
+          Pause
+        </button>
+        <button className="demo-button red-button" onClick={reset}>
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/docs/docs/hooks/useTImer.mdx
+++ b/docs/docs/hooks/useTImer.mdx
@@ -1,0 +1,58 @@
+# useTimer()
+
+The `useTimer` hook provides a simple way to manage a timer with start, pause, and reset functionalities. It supports both counting up and counting down with a customizable interval.
+
+### Import
+
+```jsx
+import { useTimer } from 'react-haiku';
+```
+
+### Usage
+
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { UseTimerDemo } from '../../demo/UseTimerDemo.jsx';
+
+<BrowserOnly fallback={<div>Loading...</div>}>
+  {() => <UseTimerDemo />}
+</BrowserOnly>
+
+```jsx
+import { useTimer } from 'react-haiku';
+export const TimerComponent = () => {
+  const { time, isRunning, start, pause, reset } = useTimer({
+    startTime: 0,
+    endTime: 10,
+    interval: 1000,
+  });
+
+  return (
+    <div>
+      <p>Time: {time}</p>
+      <button onClick={start} disabled={isRunning}>
+        Start
+      </button>
+      <button onClick={pause} disabled={!isRunning}>
+        Pause
+      </button>
+      <button onClick={reset}>Reset</button>
+    </div>
+  );
+};
+```
+
+### API
+
+This hook accepts the following arguments:
+
+- `startTime` - the initial time value for the timer
+- `endTime` - the end time value for the timer
+- `interval` (number, default: `1000`)- the interval in milliseconds to update the timer value
+
+This hook returns an object with the following properties:
+
+- `time` - the current time value of the timer
+- `isRunning` - a boolean value indicating whether the timer is running
+- `start` - a function to start the timer
+- `pause` - a function to pause the timer
+- `reset` - a function to reset the timer

--- a/lib/hooks/useTimer.ts
+++ b/lib/hooks/useTimer.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useRef } from 'react';
+
+interface UseTimerProps {
+  startTime?: number;
+  endTime?: number;
+  interval?: number;
+}
+
+interface UseTimerReturn {
+  time: number;
+  isRunning: boolean;
+  start: () => void;
+  pause: () => void;
+  reset: () => void;
+}
+
+const validateInputs = (
+  startTime?: number,
+  endTime?: number,
+  interval?: number,
+) => {
+  if (
+    typeof startTime !== 'number' ||
+    (endTime !== undefined && typeof endTime !== 'number')
+  ) {
+    throw new Error('startTime and endTime must be numbers');
+  }
+  if (interval !== undefined && interval <= 0) {
+    throw new Error('Interval must be a positive number');
+  }
+};
+
+export const useTimer = ({
+  startTime = 0,
+  endTime,
+  interval = 1000,
+}: UseTimerProps): UseTimerReturn => {
+  validateInputs(startTime, endTime, interval);
+  const [time, setTime] = useState<number>(startTime);
+  const [isRunning, setIsRunning] = useState<boolean>(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isCountingDown = endTime !== undefined && startTime > endTime;
+
+  useEffect(() => {
+    if (isRunning) {
+      timerRef.current = setInterval(() => {
+        setTime((prevTime) => {
+          const nextTime = isCountingDown ? prevTime - 1 : prevTime + 1;
+
+          //  Stop timer when it reaches the endTime
+          if (
+            (isCountingDown &&
+              nextTime <= (endTime ?? Number.NEGATIVE_INFINITY)) ||
+            (!isCountingDown &&
+              nextTime >= (endTime ?? Number.POSITIVE_INFINITY))
+          ) {
+            clearInterval(timerRef.current!);
+            setIsRunning(false); // Ensure timer stops
+            return endTime!;
+          }
+
+          return nextTime;
+        });
+      }, interval);
+    } else {
+      // Clear timer when paused or stopped
+      if (timerRef.current) clearInterval(timerRef.current);
+    }
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [isRunning, endTime, interval, isCountingDown]);
+
+  const start = () => {
+    if (!isRunning) setIsRunning(true); // Prevent multiple starts
+  };
+
+  const pause = () => {
+    if (isRunning) setIsRunning(false);
+  };
+
+  const reset = () => {
+    setIsRunning(false);
+    setTime(startTime); // Reset time to initial value
+  };
+
+  return { time, isRunning, start, pause, reset };
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,6 +38,7 @@ export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
 export { useKeyPress } from './hooks/useKeyPress';
 export { useScrollDevice } from './hooks/useScrollDevice';
+export { useTimer } from './hooks/useTimer';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';

--- a/lib/tests/hooks/useTImer.test.tsx
+++ b/lib/tests/hooks/useTImer.test.tsx
@@ -1,0 +1,147 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTimer } from '../../hooks/useTimer';
+
+describe('useTimer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should initialize with the correct start time', () => {
+    const { result } = renderHook(() => useTimer({ startTime: 10 }));
+    expect(result.current.time).toBe(10);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('should start the timer and increment time', () => {
+    const { result } = renderHook(() =>
+      useTimer({ startTime: 0, interval: 1000 }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.isRunning).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.time).toBe(1);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.time).toBe(3);
+  });
+
+  it('should pause the timer', () => {
+    const { result } = renderHook(() =>
+      useTimer({ startTime: 0, interval: 1000 }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.time).toBe(2);
+
+    act(() => {
+      result.current.pause();
+    });
+
+    expect(result.current.isRunning).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.time).toBe(2); // Time should not change after pause
+  });
+
+  it('should reset the timer', () => {
+    const { result } = renderHook(() =>
+      useTimer({ startTime: 0, interval: 1000 }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.time).toBe(3);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.time).toBe(0);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('should count down when endTime is provided and startTime > endTime', () => {
+    const { result } = renderHook(() =>
+      useTimer({ startTime: 10, endTime: 5, interval: 1000 }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.time).toBe(5);
+    expect(result.current.isRunning).toBe(false); // Timer should stop at endTime
+  });
+
+  it('should stop counting when reaching endTime', () => {
+    const { result } = renderHook(() =>
+      useTimer({ startTime: 0, endTime: 5, interval: 1000 }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.time).toBe(5);
+    expect(result.current.isRunning).toBe(false); // Timer should stop at endTime
+  });
+
+  it('should throw an error if startTime or endTime is not a number', () => {
+    expect(() => {
+      renderHook(() => useTimer({ startTime: 'not a number' as any }));
+    }).toThrow('startTime and endTime must be numbers');
+
+    expect(() => {
+      renderHook(() => useTimer({ endTime: 'not a number' as any }));
+    }).toThrow('startTime and endTime must be numbers');
+  });
+
+  it('should throw an error if interval is not a positive number', () => {
+    expect(() => {
+      renderHook(() => useTimer({ interval: 0 }));
+    }).toThrow('Interval must be a positive number');
+
+    expect(() => {
+      renderHook(() => useTimer({ interval: -100 }));
+    }).toThrow('Interval must be a positive number');
+  });
+});


### PR DESCRIPTION
## Pull Request Description:

### Summary:
This PR introduces a custom`useTimer()` hook to manage timers with start, pause, and reset functionalities, supporting both counting up and down with customizable intervals.

### Features:

- Implemented a new useTimer hook for managing timers with customizable start, pause, and reset features.
- Supports both counting up and down with configurable intervals.
- Added documentation for usage, API details, and example implementation.

### Usage

```jsx
import { useTimer } from 'react-haiku';
export const TimerComponent = () => {
  const { time, isRunning, start, pause, reset } = useTimer({
    startTime: 0,
    endTime: 10,
    interval: 1000,
  });

  return (
    <div>
      <p>Time: {time}</p>
      <button onClick={start} disabled={isRunning}>
        Start
      </button>
      <button onClick={pause} disabled={!isRunning}>
        Pause
      </button>
      <button onClick={reset}>Reset</button>
    </div>
  );
};
```
### Screenshot

<img width="846" alt="image" src="https://github.com/user-attachments/assets/2d3ea615-446a-4f68-b724-6cba7daea084" />


