### PR TITLE
feat/99-error-boundary

### DIFF
--- a/docs/demo/ErrorBoundaryDemo.tsx
+++ b/docs/demo/ErrorBoundaryDemo.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ErrorBoundary } from 'react-haiku';
+
+interface FallbackProps {
+  retry: () => void;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+}
+
+const Fallback: React.FC<FallbackProps> = ({ retry }) => {
+  return (
+    <div className="demo-container-center">
+      <b style={{ marginBottom: '1em' }}>We faced an error</b>
+      <button
+        className="demo-button"
+        onClick={retry}
+        style={{ marginBottom: '1em' }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+};
+
+// Component that will intentionally cause an error
+const CrashComponent: React.FC = () => {
+  throw new Error('This is a test error inside the ErrorBoundary!');
+};
+
+export const ErrorBoundaryDemo: React.FC = () => {
+  return (
+    <ErrorBoundary fallback={Fallback}>
+      <CrashComponent />
+    </ErrorBoundary>
+  );
+};

--- a/docs/docs/utilities/errorBoundary.mdx
+++ b/docs/docs/utilities/errorBoundary.mdx
@@ -1,0 +1,72 @@
+# Error Boundary
+
+The `ErrorBoundary` component is a utility component that catches errors in its child component tree, logs the error, and prevents the entire application from crashing by rendering a fallback UI instead..
+
+### Import
+
+```jsx
+import { ErrorBoundary } from 'react-haiku';
+```
+
+### Usage
+
+import { ErrorBoundaryDemo } from '../../demo/ErrorBoundaryDemo.tsx';
+
+<ErrorBoundaryDemo />
+
+```tsx
+import React from 'react';
+import { ErrorBoundary } from 'react-haiku';
+
+// Component that will intentionally cause an error
+const CrashComponent: React.FC = () => {
+  throw new Error('This is a test error inside the ErrorBoundary!');
+};
+
+export const ErrorBoundaryDemo: React.FC = () => {
+  return (
+    <ErrorBoundary fallback={Fallback}>
+      <CrashComponent />
+    </ErrorBoundary>
+  );
+};
+```
+
+### Fallback
+
+You can access `retry`, `error` and `errorInfo` prop in you Fallback component which you can use to create a dynamic UI.
+
+```tsx
+interface FallbackProps {
+  retry: () => void;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+}
+
+const Fallback: React.FC<FallbackProps> = ({ retry }) => {
+  return (
+    <div className="demo-container-center">
+      <b style={{ marginBottom: '1em' }}>We faced an error</b>
+      <button
+        className="demo-button"
+        onClick={retry}
+        style={{ marginBottom: '1em' }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+};
+```
+
+### API
+
+The **ErrorBoundary** accepts the following props:
+
+- `fallback` - Component to render when an error is occured in child components.
+
+The **Fallback** receives the following props:
+
+- `retry` - Function to retry/reload the wrapped component.
+- `error` - error of type **Error**
+- `errorInfo` - error info of type **React.ErrorInfo**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -46,3 +46,7 @@ export { RenderAfter } from './utils/RenderAfter';
 export { Class } from './utils/Class';
 export { Switch } from './utils/Switch';
 export { Image } from './utils/Image';
+
+// for default import
+import ErrorBoundary from './utils/ErrorBoundary';
+export { ErrorBoundary };

--- a/lib/utils/ErrorBoundary.tsx
+++ b/lib/utils/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ComponentType<{
+    error: Error | null;
+    errorInfo: React.ErrorInfo | null;
+    retry: () => void;
+  }>;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+}
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    this.setState({
+      error: error,
+      errorInfo: errorInfo,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const Fallback = this.props.fallback;
+      return (
+        <Fallback
+          error={this.state.error}
+          errorInfo={this.state.errorInfo}
+          retry={() => this.setState({ hasError: false })}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
# Usage

```tsx
import React from 'react';
import { ErrorBoundary } from 'react-haiku';

// Component that will intentionally cause an error
const CrashComponent: React.FC = () => {
  throw new Error('This is a test error inside the ErrorBoundary!');
};

export const ErrorBoundaryDemo: React.FC = () => {
  return (
    <ErrorBoundary fallback={Fallback}>
      <CrashComponent />
    </ErrorBoundary>
  );
};
```

### Fallback

You can access `retry`, `error` and `errorInfo` prop in you Fallback component which you can use to create a dynamic UI.

```tsx
interface FallbackProps {
  retry: () => void;
  error: Error | null;
  errorInfo: React.ErrorInfo | null;
}

const Fallback: React.FC<FallbackProps> = ({ retry }) => {
  return (
    <div className="demo-container-center">
      <b style={{ marginBottom: '1em' }}>We faced an error</b>
      <button
        className="demo-button"
        onClick={retry}
        style={{ marginBottom: '1em' }}
      >
        Retry
      </button>
    </div>
  );
};
```