### PR TITLE
refactor: enhance cookie hooks with type safety and parsing improvements

### DIFF
--- a/lib/helpers/cookie.ts
+++ b/lib/helpers/cookie.ts
@@ -1,50 +1,55 @@
-export const parseToDataType = (
-  value: string | undefined,
-  isItRetry = false,
-): any => {
-  try {
-    return value === 'undefined' || value === undefined
-      ? undefined
-      : JSON.parse(value);
-  } catch (e) {
-    if (!isItRetry) {
-      return parseToDataType(`"${value?.replaceAll?.('"', '')}"`, true);
-    }
+export const parseToDataType = <T>(
+	value: string | undefined,
+	isItRetry = false,
+): T | undefined => {
+	try {
+		return value === "undefined" || value === undefined
+			? undefined
+			: (JSON.parse(value) as T);
+	} catch (e) {
+		if (!isItRetry) {
+			return parseToDataType<T>(`"${value?.replaceAll?.('"', "")}"`, true);
+		}
 
-    return undefined;
-  }
+		return undefined;
+	}
 };
 
 export const parseToCookieType = <T>(value: T) => {
-  if (typeof value === 'string') {
-    return value;
-  }
+	if (typeof value === "string") {
+		return value;
+	}
 
-  return JSON.stringify(value);
+	return JSON.stringify(value);
 };
 
-export const getCookie = (name: string) => {
-  const value = `; ${document.cookie}`;
+export const getCookie = <T>(name: string): T | undefined => {
+	const value = `; ${document.cookie}`;
 
-  const [_, cookie] = value.split(`; ${name}=`);
+	const [_, cookie] = value.split(`; ${name}=`);
 
-  return cookie ? parseToDataType(cookie.split(';')[0]) : cookie;
+	return cookie ? parseToDataType<T>(cookie.split(";")[0]) : undefined;
 };
 
-export const getCookies = (cookies: string[] = []) => {
-  if (cookies.length)
-    return cookies.reduce(
-      (result, cookie) => ({ ...result, [cookie]: getCookie(cookie) }),
-      {},
-    );
+export const getCookies = <T extends Record<string, unknown> = Record<string, unknown>>(
+	cookies: string[] = [],
+): T => {
+	if (cookies.length) {
+		return cookies.reduce<Partial<T>>(
+			(result, cookie) => ({
+				...result,
+				[cookie]: getCookie<T[typeof cookie]>(cookie),
+			}),
+			{},
+		) as T;
+	}
 
-  return Object.fromEntries(
-    document.cookie.split('; ').map((c) => {
-      const [key, value] = c.split('=');
-
-      return [key, parseToDataType(value)];
-    }),
-  );
+	return Object.fromEntries(
+		document.cookie.split("; ").map((c) => {
+			const [key, value] = c.split("=");
+			return [key, parseToDataType<unknown>(value)];
+		}),
+	) as T;
 };
 
 export const setCookie = <T>(name: string, value: T, expireDays: number) => {
@@ -62,3 +67,5 @@ export const setCookie = <T>(name: string, value: T, expireDays: number) => {
 export const deleteCookie = (name: string) => {
   document.cookie = `${name}=; path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };
+
+

--- a/lib/hooks/useCookie.ts
+++ b/lib/hooks/useCookie.ts
@@ -12,35 +12,35 @@ import {
 } from '../helpers/cookie';
 
 export const useCookie = <T>(
-  key: string,
-  initialValue: T,
-  expireDays = 365,
+	key: string,
+	initialValue: T,
+	expireDays = 365,
 ) => {
-  const [cookieValue, setCookieValue] = useState<T>(
-    getCookie(key) ?? parseToDataType(parseToCookieType(initialValue)),
-  );
+	const [cookieValue, setCookieValue] = useState<T>(
+		parseToDataType<T>(parseToCookieType(getCookie(key))) ?? initialValue,
+	);
 
-  useSingleEffect(() => {
-    if (typeof getCookie(key) === 'undefined') {
-      setCookie(key, initialValue, expireDays);
-    }
-  });
+	useSingleEffect(() => {
+		if (typeof getCookie(key) === "undefined") {
+			setCookie(key, initialValue, expireDays);
+		}
+	});
 
-  useCookieListener(
-    (value: T) => {
-      setCookieValue(value);
-    },
-    [key],
-  );
+	useCookieListener(
+		(value: T) => {
+			setCookieValue(value);
+		},
+		[key],
+	);
 
-  const setValue = (value: T) => {
-    setCookieValue(value);
-    setCookie(key, value, expireDays);
-  };
+	const setValue = (value: T) => {
+		setCookieValue(value);
+		setCookie(key, value, expireDays);
+	};
 
-  const deleteValue = () => {
-    deleteCookie(key);
-  };
+	const deleteValue = () => {
+		deleteCookie(key);
+	};
 
-  return [cookieValue, setValue, deleteValue];
+	return [cookieValue, setValue, deleteValue];
 };

--- a/lib/hooks/useCookie.ts
+++ b/lib/hooks/useCookie.ts
@@ -17,7 +17,7 @@ export const useCookie = <T>(
 	expireDays = 365,
 ) => {
 	const [cookieValue, setCookieValue] = useState<T>(
-		parseToDataType<T>(parseToCookieType(getCookie(key))) ?? initialValue,
+		getCookie<T>(key) ?? initialValue,
 	);
 
 	useSingleEffect(() => {

--- a/lib/hooks/useCookieListener.ts
+++ b/lib/hooks/useCookieListener.ts
@@ -1,12 +1,12 @@
 import { useRef, useEffect } from 'react';
 
-import { parseToCookieType, getCookies } from '../helpers/cookie';
+import { parseToCookieType, getCookies, parseToDataType } from '../helpers/cookie';
 
-export const useCookieListener = (
-  effect: (a: any, b: string) => void,
+export const useCookieListener = <T>(
+  effect: (a: T, b: string) => void,
   cookies: string[],
 ) => {
-  const cookieValues = useRef(getCookies(cookies));
+  const cookieValues = useRef<Record<string, unknown>>(getCookies(cookies));
 
   useEffect(() => {
     const cookieOnChange = () => {
@@ -24,7 +24,12 @@ export const useCookieListener = (
               [cookieKey]: currentCookie,
             };
 
-            effect(currentCookie, cookieKey);
+            const parsedValue = parseToDataType<T>(
+              parseToCookieType(currentCookie),
+            );
+            if (parsedValue !== undefined) {
+              effect(parsedValue, cookieKey);
+            }
           }
         },
       );

--- a/lib/hooks/useSingleEffect.ts
+++ b/lib/hooks/useSingleEffect.ts
@@ -1,26 +1,25 @@
 import { useEffect, useRef } from 'react';
 
-export function useSingleEffect(effect: any) {
-  const destroy = useRef();
-  const calledOnce = useRef(false);
-  const renderAfterCalled = useRef(false);
+export function useSingleEffect(effect: () => void | (() => void)) {
+	const destroy = useRef<void | (() => void)>(undefined);
+	const calledOnce = useRef(false);
+	const renderAfterCalled = useRef(false);
 
-  if (calledOnce.current) renderAfterCalled.current = true;
+	if (calledOnce.current) renderAfterCalled.current = true;
 
-  useEffect(() => {
-    if (calledOnce.current) {
-      return;
-    }
+	useEffect(() => {
+		if (calledOnce.current) {
+			return;
+		}
 
-    calledOnce.current = true;
-    destroy.current = effect();
+		calledOnce.current = true;
+		destroy.current = effect();
 
-    return () => {
-      if (!renderAfterCalled.current) {
-        return;
-      }
-      // @ts-ignore
-      if (destroy.current) destroy.current();
-    };
-  }, []);
+		return () => {
+			if (!renderAfterCalled.current) {
+				return;
+			}
+			if (destroy.current) destroy.current();
+		};
+	}, [effect]);
 }


### PR DESCRIPTION
## Changes to Type Safety in useCookieListener

You've improved type safety in the `useCookieListener` hook in several key ways:

1. Added a generic type parameter `<T>` to the hook function signature, ensuring that the effect callback receives properly typed data
2. Made the effect callback parameters properly typed: `effect: (a: T, b: string) => void`
3. Used the generic type in `parseToDataType<T>()` to ensure the parsed cookie value matches the expected type
4. Added a check `if (parsedValue !== undefined)` to only call the effect when a valid value exists
5. Used a properly typed `Record<string, unknown>` for storing cookie values

These changes ensure type consistency throughout the cookie listening process and prevent potential runtime errors from mismatched types.