### PR TITLE
fix(event helpers): check for removeEventListener in off() instead of addEventListener

### DIFF
--- a/lib/helpers/event.ts
+++ b/lib/helpers/event.ts
@@ -11,5 +11,5 @@ export const off = <T extends EventTarget, A extends any[]>(
   ...args: A
 ) => {
   // @ts-ignore
-  if (obj && obj.addEventListener) obj.removeEventListener(...args);
+  if (obj && obj.removeEventListener) obj.removeEventListener(...args);
 };


### PR DESCRIPTION
Fixed the off function to check for `removeEventListener` instead of `addEventListener`