### PR TITLE
Fix `useLeaveDetection` to always invoke latest callback

### DIFF
--- a/lib/hooks/useLeaveDetection.ts
+++ b/lib/hooks/useLeaveDetection.ts
@@ -1,12 +1,22 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export function useLeaveDetection(
   onLeave: (this: HTMLElement, ev: MouseEvent) => any,
 ) {
+  const onLeaveRef = useRef(onLeave);
+
   useEffect(() => {
-    document.documentElement.addEventListener('mouseleave', onLeave);
+    onLeaveRef.current = onLeave;
+  }, [onLeave]);
+
+  useEffect(() => {
+    const handler = function (this: HTMLElement, ev: MouseEvent) {
+      onLeaveRef.current.call(this, ev);
+    };
+
+    document.documentElement.addEventListener('mouseleave', handler);
 
     return () =>
-      document.documentElement.removeEventListener('mouseleave', onLeave);
+      document.documentElement.removeEventListener('mouseleave', handler);
   }, []);
 }

--- a/lib/tests/hooks/useLeaveDetection.test.tsx
+++ b/lib/tests/hooks/useLeaveDetection.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { useLeaveDetection } from '../../hooks/useLeaveDetection';
+import { useState } from 'react';
+
+describe('useLeaveDetection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call the passed callback when the mouse leaves the document', () => {
+    const callback = jest.fn();
+    renderHook(() => useLeaveDetection(callback));
+
+    fireEvent.mouseLeave(document.documentElement);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should setup the event listener only once', () => {
+    const spy = jest.spyOn(document.documentElement, 'addEventListener');
+    const { rerender } = renderHook(() => useLeaveDetection(() => {}));
+
+    rerender();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('mouseleave', expect.any(Function));
+  });
+
+  it('should remove the event listener on unmount', () => {
+    const spy = jest.spyOn(document.documentElement, 'removeEventListener');
+    const callback = jest.fn();
+    const { unmount } = renderHook(() => useLeaveDetection(callback));
+
+    unmount();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('mouseleave', expect.any(Function));
+
+    fireEvent.mouseLeave(document.documentElement);
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+
+  it('should always invoke the latest callback', () => {
+    const Test = () => {
+      const [count, setCount] = useState(0);
+      useLeaveDetection(() => setCount(count + 1));
+      return <div>{count}</div>;
+    };
+    render(<Test />);
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(document.documentElement);
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(document.documentElement);
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(document.documentElement);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('should invoke the callback with correct argument and `this` context', () => {
+    const callback = function (this: HTMLElement, ev: MouseEvent) {
+      expect(this).toBe(document.documentElement);
+      expect(ev).toBeInstanceOf(MouseEvent);
+      expect(ev.type).toBe('mouseleave');
+    };
+    renderHook(() => useLeaveDetection(callback));
+
+    fireEvent.mouseLeave(document.documentElement);
+  });
+});


### PR DESCRIPTION
The `useLeaveDetection` hook currently sets up the `mouseleave` event listener only once (due to the empty `useEffect` dependency). This means the hook always invokes the very first `onLeave` callback passed to it, rather than the latest one.
https://github.com/DavidHDev/haiku/blob/259ab50a9bc5b48de9141c1ae1d492c972e00705/lib/hooks/useLeaveDetection.ts#L3-L12

<br>

Now, this works in the documentation example because it uses the callback approach to update the state.
https://github.com/DavidHDev/haiku/blob/259ab50a9bc5b48de9141c1ae1d492c972e00705/docs/src/components/Demo/LeaveDetection.js#L5-L6

However, if the state is updated directly by passing a value, then the hook breaks, because it fails to invoke the latest callback everytime the `mouseleave` event occurs, instead it keeps calling the initial callback (`() => setLeaveCount(0 + 1)`).
```ts
const [leaveCount, setLeaveCount] = React.useState(0); 
useLeaveDetection(() => setLeaveCount(leaveCount + 1));
```

<br>

A simple fix would be to add `onLeave` to the `useEffect` dependency array:
```diff
export function useLeaveDetection( 
   onLeave: (this: HTMLElement, ev: MouseEvent) => any, 
 ) { 
   useEffect(() => { 
     document.documentElement.addEventListener('mouseleave', onLeave); 
  
     return () => 
       document.documentElement.removeEventListener('mouseleave', onLeave); 
-   }, []);
+   }, [onLeave]);
 }
```
While this works, it's not ideal. Each time a new callback is passed, a new event listener is set up. Since it's easy to pass a new callback on every render, this places the burden of memoizing the callback on the user, which doesn’t make for a great API.

<br>

This PR updates the implementation to fix the stale callback issue while ensuring the listener is set up only once. I've also added a comprehensive set of tests to verify that everything works as expected.