### PR TITLE
Add useScreenSize() Hook for Responsive Breakpoint Detection with Type Support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@ export default Component;
 - [`useSize()`](https://reacthaiku.dev/docs/hooks/useSize) - hook observes a referenced DOM element and returns its current width and height, updating the values whenever the element is resized. This is useful for dynamically tracking size changes of any resizable component.
 - [`useDeviceOS()`](https://reacthaiku.dev/docs/hooks/useDeviceOS) - Detects the user's operating system, including mobile emulators, and uses string manipulation for identifying unique or new OS versions.
 - [`usePreventBodyScroll()`](https://reacthaiku.dev/docs/hooks/usePreventBodyScroll) - Disables body scrolling when active and restores it upon deactivation or component unmounting. It provides a boolean state, a setter, and a toggle function for dynamic scroll control.
+- [`useScreenSize()`](https://reacthaiku.dev/docs/hooks/useScreenSize) - Provide the breakponint values in string method `toString`  with other method `euqals` , `lessThan` , `greaterThan` value in `True/False`.
 
 ### Utilities
 

--- a/docs/demo/UseScreenSizeDemo.jsx
+++ b/docs/demo/UseScreenSizeDemo.jsx
@@ -1,0 +1,16 @@
+import { useScreenSize } from 'react-haiku';
+import React from 'react';
+
+
+export const UseScreenSizeDemo = () => {
+  const screenSize = useScreenSize();
+
+  return (
+    <div className="demo-container-center">
+      <h1>Current Screen Size: {screenSize.toString()}</h1>
+      <p>Is the screen size medium ? {screenSize.equals("md") ? "Yes" : "No"}</p>
+      <p>Is the screen size less than large ? {screenSize.lessThan("lg") ? "Yes" : "No"}</p>
+      <p>Is the screen size greater than small ? {screenSize.greaterThan("sm") ? "Yes" : "No"}</p>
+    </div>
+  );
+}

--- a/docs/docs/hooks/useScreenSize.mdx
+++ b/docs/docs/hooks/useScreenSize.mdx
@@ -1,0 +1,33 @@
+# useScreenSize()
+
+The `useScreenSize()` hook allows responsive breakpoint detection in components. It returns helper methods (`equals`, `lessThan`, `greaterThan`) and a string method (`toString`) representing the current screen size: `xs`, `sm`, `md`, `lg`, `xl`, or `2xl for size bigger than 1535 pixel`.
+
+### Import
+
+```jsx
+import { useScreenSize } from 'react-haiku';
+```
+
+
+### Usage
+
+import { UseScreenSizeDemo } from '../../demo/UseScreenSizeDemo.jsx';
+
+<UseScreenSizeDemo />
+
+```jsx
+import { useScreenSize } from 'react-haiku';
+
+export const MyComponent = () => {
+  const screenSize = useScreenSize();
+
+  return (
+    <div>
+      <h1>Current Screen Size: {screenSize.toString()}</h1>
+      <p>Is the screen size medium? {screenSize.equals("md") ? "Yes" : "No"}</p>
+      <p>Is the screen size less than large? {screenSize.lessThan("lg") ? "Yes" : "No"}</p>
+      <p>Is the screen size greater than small? {screenSize.greaterThan("sm") ? "Yes" : "No"}</p>
+    </div>
+  );
+};
+```

--- a/lib/hooks/useScreenSize.ts
+++ b/lib/hooks/useScreenSize.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+// Breakpoint size mappings
+const breakpoints = {
+  xs: 639,
+  sm: 767,
+  md: 1023,
+  lg: 1279,
+  xl: 1535,
+  '2xl': Infinity, // 2xl is anything above 1535px
+};
+
+// Helper function to get the current breakpoint
+const getBreakpoint = (width: number): keyof typeof breakpoints => {
+  if (width <= breakpoints.xs) return 'xs';
+  if (width <= breakpoints.sm) return 'sm';
+  if (width <= breakpoints.md) return 'md';
+  if (width <= breakpoints.lg) return 'lg';
+  if (width <= breakpoints.xl) return 'xl';
+  return '2xl';
+};
+
+// The custom hook
+export const useScreenSize = () => {
+  const [screenSize, setScreenSize] = useState<keyof typeof breakpoints>('xs');
+
+  const handleResize = () => {
+    setScreenSize(getBreakpoint(window.innerWidth));
+  };
+
+  useEffect(() => {
+    handleResize(); // Set the initial size
+    window.addEventListener('resize', handleResize); // Update on window resize
+
+    return () => {
+      window.removeEventListener('resize', handleResize); // Cleanup on unmount
+    };
+  }, []);
+
+  // Methods to check size
+  const equals = (size: keyof typeof breakpoints) => screenSize === size;
+  const lessThan = (size: keyof typeof breakpoints) => breakpoints[screenSize] < breakpoints[size];
+  const greaterThan = (size: keyof typeof breakpoints) => breakpoints[screenSize] > breakpoints[size];
+
+  return {
+    equals,
+    lessThan,
+    greaterThan,
+    toString: () => screenSize,
+  };
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,6 +38,7 @@ export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
 export { useKeyPress } from './hooks/useKeyPress';
 export { useScrollDevice } from './hooks/useScrollDevice';
+export { useScreenSize } from './hooks/useScreenSize';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';


### PR DESCRIPTION
## 📝 Description

 `useScreenSize()` that enables responsive breakpoint detection in a type-safe manner using TypeScript. It simplifies working with responsive UI by allowing developers to easily check the current screen size and compare it against standard Tailwind-style breakpoints.

### 📐 Breakpoint Table

| Breakpoint | Range           |
|------------|------------------|
| `xs`       | 0px - 639px      |
| `sm`       | 640px - 767px    |
| `md`       | 768px - 1023px   |
| `lg`       | 1024px - 1279px  |
| `xl`       | 1280px - 1535px  |
| `2xl`      | 1536px and up    |

---

## 🧩 Hook API

```ts
const screenSize = useScreenSize();

screenSize.equals("md");      // true/false
screenSize.lessThan("lg");    // true/false
screenSize.greaterThan("sm"); // true/false
screenSize.toString();        // "xs" | "sm" | "md" | "lg" | "xl" | "2xl"


