### PR TITLE
Adds useGeolocation hook with documentation and demo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@ export default Component;
 - [`useSize()`](https://reacthaiku.dev/docs/hooks/useSize) - hook observes a referenced DOM element and returns its current width and height, updating the values whenever the element is resized. This is useful for dynamically tracking size changes of any resizable component.
 - [`useDeviceOS()`](https://reacthaiku.dev/docs/hooks/useDeviceOS) - Detects the user's operating system, including mobile emulators, and uses string manipulation for identifying unique or new OS versions.
 - [`usePreventBodyScroll()`](https://reacthaiku.dev/docs/hooks/usePreventBodyScroll) - Disables body scrolling when active and restores it upon deactivation or component unmounting. It provides a boolean state, a setter, and a toggle function for dynamic scroll control.
+- [`useGeolocation()`](https://reacthaiku.dev/docs/hooks/useGeolocation) - Access the user's current geographical location using the browser's Geolocation API. Returns latitude and longitude coordinates and handles permission errors gracefully.
 
 ### Utilities
 

--- a/docs/demo/UseGeolocationDemo.jsx
+++ b/docs/demo/UseGeolocationDemo.jsx
@@ -1,0 +1,43 @@
+import { useGeolocation } from 'react-haiku';
+import React from 'react';
+
+export const UseGeolocationDemo = () => {
+  const { latitude, longitude, error, loading } = useGeolocation({
+    enableHighAccuracy: true,
+    timeout: 10000,
+  });
+  
+  return (
+    <div className="demo-container-center">
+      <b style={{ "marginBottom": "1em" }}>Geolocation Tracker!</b>
+      
+      {loading && (
+        <p style={{ "marginBottom": "0", "color": "#007acc" }}>
+          Loading location...
+        </p>
+      )}
+      
+      {error && (
+        <div style={{ "marginBottom": "0", "color": "#ff4444" }}>
+          <p style={{ "marginBottom": "0" }}>Error: {error.message}</p>
+          <p style={{ "marginBottom": "0" }}>Code: {error.code}</p>
+        </div>
+      )}
+      
+      {!loading && !error && latitude !== null && longitude !== null && (
+        <div>
+          <p style={{ "marginBottom": "0" }}>
+            Latitude: <span style={{"color": "#E46B39"}}>{latitude.toFixed(6)}</span>
+          </p>
+          <p style={{ "marginBottom": "0" }}>
+            Longitude: <span style={{"color": "#E46B39"}}>{longitude.toFixed(6)}</span>
+          </p>
+        </div>
+      )}
+      
+      <small style={{ "marginTop": "1em", "color": "#888" }}>
+        Note: You may need to allow location permission in your browser.
+      </small>
+    </div>
+  );
+}

--- a/docs/docs/hooks/useGeolocation.mdx
+++ b/docs/docs/hooks/useGeolocation.mdx
@@ -1,0 +1,109 @@
+# useGeolocation()
+
+The `useGeolocation()` hook provides access to the user's current geographical location using the browser's Geolocation API. It returns latitude and longitude coordinates and handles permission errors gracefully.
+
+### Import
+
+```jsx
+import { useGeolocation } from 'react-haiku';
+```
+
+### Usage
+
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { UseGeolocationDemo } from '../../demo/UseGeolocationDemo.jsx';
+
+<BrowserOnly fallback={<div>Loading...</div>}>
+  {() => <UseGeolocationDemo />}
+</BrowserOnly>
+
+```jsx
+import { useGeolocation } from 'react-haiku';
+
+export const Component = () => {
+  const { latitude, longitude, error, loading } = useGeolocation();
+  
+  if (loading) {
+    return <div>Getting your location...</div>;
+  }
+  
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+  
+  return (
+    <div>
+      <p>Latitude: {latitude}</p>
+      <p>Longitude: {longitude}</p>
+    </div>
+  );
+};
+```
+
+### Advanced Usage
+
+```jsx
+import { useGeolocation } from 'react-haiku';
+
+export const Component = () => {
+  const { latitude, longitude, error, loading } = useGeolocation({
+    enableHighAccuracy: true,
+    timeout: 10000,
+    maximumAge: 60000,
+    watch: true // Continuously watch position changes
+  });
+  
+  return (
+    <div>
+      {loading && <p>Loading...</p>}
+      {error && <p>Error: {error.message}</p>}
+      {latitude && longitude && (
+        <div>
+          <p>Current Location:</p>
+          <p>Lat: {latitude.toFixed(6)}</p>
+          <p>Lng: {longitude.toFixed(6)}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+### Options
+
+The `useGeolocation` hook accepts an optional configuration object:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enableHighAccuracy` | `boolean` | `false` | Indicates that the application would like to receive the most accurate results possible |
+| `timeout` | `number` | `5000` | Maximum length of time (in milliseconds) that is allowed to pass before a timeout error occurs |
+| `maximumAge` | `number` | `0` | Maximum age in milliseconds of a possible cached position that is acceptable to return |
+| `watch` | `boolean` | `false` | If true, the hook will continuously watch for position changes instead of getting the position once |
+
+### Return Values
+
+The hook returns an object with the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `latitude` | `number \| null` | The latitude coordinate of the current position |
+| `longitude` | `number \| null` | The longitude coordinate of the current position |
+| `error` | `GeolocationError \| null` | Error object containing code and message if an error occurred |
+| `loading` | `boolean` | Indicates whether the geolocation request is in progress |
+
+### Error Handling
+
+The hook handles various types of geolocation errors:
+
+- **Permission Denied**: User denied the request for geolocation
+- **Position Unavailable**: Location information is unavailable
+- **Timeout**: The request to get user location timed out
+- **Not Supported**: Geolocation is not supported by the browser
+
+### Browser Support
+
+This hook requires the browser to support the Geolocation API. Most modern browsers support this feature, but users must grant permission for the website to access their location.
+
+### Privacy Note
+
+Always inform users why you need their location data and respect their privacy choices. The geolocation feature requires explicit user permission.

--- a/docs/docs/hooks/useGeolocation.mdx
+++ b/docs/docs/hooks/useGeolocation.mdx
@@ -1,6 +1,6 @@
 # useGeolocation()
 
-The `useGeolocation()` hook provides access to the user's current geographical location using the browser's Geolocation API. It returns latitude and longitude coordinates and handles permission errors gracefully.
+The `useGeolocation()` hook provides access to the user's current geographical location using the browser's Geolocation API.
 
 ### Import
 
@@ -21,16 +21,19 @@ import { UseGeolocationDemo } from '../../demo/UseGeolocationDemo.jsx';
 import { useGeolocation } from 'react-haiku';
 
 export const Component = () => {
-  const { latitude, longitude, error, loading } = useGeolocation();
-  
+  const { latitude, longitude, error, loading } = useGeolocation({
+    enableHighAccuracy: true,
+    timeout: 10000,
+  });
+
   if (loading) {
     return <div>Getting your location...</div>;
   }
-  
+
   if (error) {
     return <div>Error: {error.message}</div>;
   }
-  
+
   return (
     <div>
       <p>Latitude: {latitude}</p>
@@ -40,70 +43,18 @@ export const Component = () => {
 };
 ```
 
-### Advanced Usage
+### API
 
-```jsx
-import { useGeolocation } from 'react-haiku';
+This hook accepts an optional configuration object with the following properties:
 
-export const Component = () => {
-  const { latitude, longitude, error, loading } = useGeolocation({
-    enableHighAccuracy: true,
-    timeout: 10000,
-    maximumAge: 60000,
-    watch: true // Continuously watch position changes
-  });
-  
-  return (
-    <div>
-      {loading && <p>Loading...</p>}
-      {error && <p>Error: {error.message}</p>}
-      {latitude && longitude && (
-        <div>
-          <p>Current Location:</p>
-          <p>Lat: {latitude.toFixed(6)}</p>
-          <p>Lng: {longitude.toFixed(6)}</p>
-        </div>
-      )}
-    </div>
-  );
-};
-```
+- `enableHighAccuracy` - boolean to request the most accurate results possible, defaults to `false`
+- `timeout` - maximum time in milliseconds to wait before timeout, defaults to `5000`
+- `maximumAge` - maximum age of cached position in milliseconds, defaults to `0`
+- `watch` - boolean to continuously watch for position changes, defaults to `false`
 
-### Options
+The hook returns an object with:
 
-The `useGeolocation` hook accepts an optional configuration object:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enableHighAccuracy` | `boolean` | `false` | Indicates that the application would like to receive the most accurate results possible |
-| `timeout` | `number` | `5000` | Maximum length of time (in milliseconds) that is allowed to pass before a timeout error occurs |
-| `maximumAge` | `number` | `0` | Maximum age in milliseconds of a possible cached position that is acceptable to return |
-| `watch` | `boolean` | `false` | If true, the hook will continuously watch for position changes instead of getting the position once |
-
-### Return Values
-
-The hook returns an object with the following properties:
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `latitude` | `number \| null` | The latitude coordinate of the current position |
-| `longitude` | `number \| null` | The longitude coordinate of the current position |
-| `error` | `GeolocationError \| null` | Error object containing code and message if an error occurred |
-| `loading` | `boolean` | Indicates whether the geolocation request is in progress |
-
-### Error Handling
-
-The hook handles various types of geolocation errors:
-
-- **Permission Denied**: User denied the request for geolocation
-- **Position Unavailable**: Location information is unavailable
-- **Timeout**: The request to get user location timed out
-- **Not Supported**: Geolocation is not supported by the browser
-
-### Browser Support
-
-This hook requires the browser to support the Geolocation API. Most modern browsers support this feature, but users must grant permission for the website to access their location.
-
-### Privacy Note
-
-Always inform users why you need their location data and respect their privacy choices. The geolocation feature requires explicit user permission.
+- `latitude` - the latitude coordinate or `null`
+- `longitude` - the longitude coordinate or `null`
+- `error` - error object with `code` and `message` properties, or `null`
+- `loading` - boolean indicating if the request is in progress

--- a/lib/hooks/useGeolocation.ts
+++ b/lib/hooks/useGeolocation.ts
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+
+interface GeolocationCoordinates {
+  latitude: number | null;
+  longitude: number | null;
+}
+
+interface GeolocationError {
+  code: number;
+  message: string;
+}
+
+interface UseGeolocationReturn {
+  latitude: number | null;
+  longitude: number | null;
+  error: GeolocationError | null;
+  loading: boolean;
+}
+
+interface UseGeolocationOptions {
+  enableHighAccuracy?: boolean;
+  timeout?: number;
+  maximumAge?: number;
+  watch?: boolean;
+}
+
+export function useGeolocation(options: UseGeolocationOptions = {}): UseGeolocationReturn {
+  const {
+    enableHighAccuracy = false,
+    timeout = 5000,
+    maximumAge = 0,
+    watch = false,
+  } = options;
+
+  const [position, setPosition] = useState<GeolocationCoordinates>({
+    latitude: null,
+    longitude: null,
+  });
+  const [error, setError] = useState<GeolocationError | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setError({
+        code: 0,
+        message: 'Geolocation is not supported by this browser.',
+      });
+      setLoading(false);
+      return;
+    }
+
+    const positionOptions: PositionOptions = {
+      enableHighAccuracy,
+      timeout,
+      maximumAge,
+    };
+
+    const onSuccess = (geolocationPosition: GeolocationPosition) => {
+      setPosition({
+        latitude: geolocationPosition.coords.latitude,
+        longitude: geolocationPosition.coords.longitude,
+      });
+      setError(null);
+      setLoading(false);
+    };
+
+    const onError = (error: GeolocationPositionError) => {
+      let message: string;
+      
+      switch (error.code) {
+        case error.PERMISSION_DENIED:
+          message = 'User denied the request for Geolocation.';
+          break;
+        case error.POSITION_UNAVAILABLE:
+          message = 'Location information is unavailable.';
+          break;
+        case error.TIMEOUT:
+          message = 'The request to get user location timed out.';
+          break;
+        default:
+          message = 'An unknown error occurred.';
+          break;
+      }
+
+      setError({
+        code: error.code,
+        message,
+      });
+      setLoading(false);
+    };
+
+    let watchId: number | undefined;
+
+    if (watch) {
+      watchId = navigator.geolocation.watchPosition(onSuccess, onError, positionOptions);
+    } else {
+      navigator.geolocation.getCurrentPosition(onSuccess, onError, positionOptions);
+    }
+
+    return () => {
+      if (watchId !== undefined) {
+        navigator.geolocation.clearWatch(watchId);
+      }
+    };
+  }, [enableHighAccuracy, timeout, maximumAge, watch]);
+
+  return {
+    latitude: position.latitude,
+    longitude: position.longitude,
+    error,
+    loading,
+  };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,6 +42,7 @@ export { useScrollDevice } from './hooks/useScrollDevice';
 export { usePermission, UsePermissionState } from './hooks/usePermission';
 export { useTimer } from './hooks/useTimer';
 export { useWebSocket } from './hooks/useWebSocket';
+export { useGeolocation } from './hooks/useGeolocation';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';

--- a/lib/tests/hooks/useGeolocation.test.tsx
+++ b/lib/tests/hooks/useGeolocation.test.tsx
@@ -1,0 +1,158 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useGeolocation } from '../../hooks/useGeolocation';
+
+// Mock the geolocation API
+const mockGeolocation = {
+  getCurrentPosition: jest.fn(),
+  watchPosition: jest.fn(),
+  clearWatch: jest.fn(),
+};
+
+// Mock navigator.geolocation
+Object.defineProperty(window.navigator, 'geolocation', {
+  value: mockGeolocation,
+  writable: true,
+});
+
+describe('useGeolocation Hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns initial state correctly', () => {
+    const { result } = renderHook(() => useGeolocation());
+
+    expect(result.current.latitude).toBe(null);
+    expect(result.current.longitude).toBe(null);
+    expect(result.current.error).toBe(null);
+    expect(result.current.loading).toBe(true);
+  });
+
+  test('handles successful geolocation', async () => {
+    const mockPosition = {
+      coords: {
+        latitude: 40.7128,
+        longitude: -74.0060,
+      },
+    };
+
+    mockGeolocation.getCurrentPosition.mockImplementation((success) => {
+      success(mockPosition);
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.latitude).toBe(40.7128);
+    expect(result.current.longitude).toBe(-74.0060);
+    expect(result.current.error).toBe(null);
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+  });
+
+  test('handles geolocation errors', async () => {
+    const mockError = {
+      code: 1,
+      PERMISSION_DENIED: 1,
+      POSITION_UNAVAILABLE: 2,
+      TIMEOUT: 3,
+    };
+
+    mockGeolocation.getCurrentPosition.mockImplementation((_success, error) => {
+      error(mockError);
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.latitude).toBe(null);
+    expect(result.current.longitude).toBe(null);
+    expect(result.current.error).toEqual({
+      code: 1,
+      message: 'User denied the request for Geolocation.',
+    });
+  });
+
+  test('handles unsupported geolocation', () => {
+    // Temporarily remove geolocation support
+    const originalGeolocation = window.navigator.geolocation;
+    Object.defineProperty(window.navigator, 'geolocation', {
+      value: undefined,
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toEqual({
+      code: 0,
+      message: 'Geolocation is not supported by this browser.',
+    });
+
+    // Restore geolocation
+    Object.defineProperty(window.navigator, 'geolocation', {
+      value: originalGeolocation,
+      writable: true,
+    });
+  });
+
+  test('handles watch mode', async () => {
+    const mockPosition = {
+      coords: {
+        latitude: 40.7128,
+        longitude: -74.0060,
+      },
+    };
+
+    let watchCallback: ((position: any) => void) | null = null;
+    const watchId = 123;
+
+    mockGeolocation.watchPosition.mockImplementation((success) => {
+      watchCallback = success;
+      return watchId;
+    });
+
+    const { result, unmount } = renderHook(() => useGeolocation({ watch: true }));
+
+    expect(mockGeolocation.watchPosition).toHaveBeenCalledTimes(1);
+
+    // Simulate position update
+    act(() => {
+      if (watchCallback) {
+        watchCallback(mockPosition);
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.latitude).toBe(40.7128);
+    expect(result.current.longitude).toBe(-74.0060);
+
+    // Test cleanup
+    unmount();
+    expect(mockGeolocation.clearWatch).toHaveBeenCalledWith(watchId);
+  });
+
+  test('passes correct options to getCurrentPosition', () => {
+    const options = {
+      enableHighAccuracy: true,
+      timeout: 10000,
+      maximumAge: 60000,
+    };
+
+    renderHook(() => useGeolocation(options));
+
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      options
+    );
+  });
+});


### PR DESCRIPTION
Introduces a hook to access user geolocation using the browser's Geolocation API. Includes comprehensive error handling for permission requests and browser support.

- Provides usage documentation and examples
- Adds a demonstration component for practical understanding
- Implements unit tests for functionality and edge cases

This enhancement provides a streamlined way for developers to incorporate geolocation features into their applications.

Relates to enhancement request #93